### PR TITLE
Change to standard generated file extension

### DIFF
--- a/BeaKona.AutoInterfaceGenerator/AutoInterfaceSourceGenerator.cs
+++ b/BeaKona.AutoInterfaceGenerator/AutoInterfaceSourceGenerator.cs
@@ -98,7 +98,7 @@ public class AutoInterfaceSourceGenerator : ISourceGenerator
 #if PEEK_1
                                 GeneratePreview(context, name, code);
 #else
-                                context.AddSource($"{name}_AutoInterface.cs", SourceText.From(code, Encoding.UTF8));
+                                context.AddSource($"{name}_AutoInterface.g.cs", SourceText.From(code, Encoding.UTF8));
 #endif
                             }
                         }


### PR DESCRIPTION
Change to generate file with .g.cs extension since this is the standard, and allows use of coverlet despite coverlet issue: https://github.com/coverlet-coverage/coverlet/issues/1164